### PR TITLE
pin node engine to v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "hexo-renderer-stylus": "^1.1.0",
     "hexo-renderer-marked": "^2.0.0",
     "hexo-server": "^1.0.0"
+  },
+  "engines": {
+	"node": "21.x"
   }
 }


### PR DESCRIPTION
Node v20 has this issue : https://github.com/nodejs/node/issues/50979
This PR pins node engine to v21.x 